### PR TITLE
Ignore device IDs that start with an underscore

### DIFF
--- a/bondhome/api.go
+++ b/bondhome/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -120,7 +121,7 @@ func (c *restAPIClient) GetDeviceIDs() ([]string, error) {
 	ids := make([]string, 0, len(responseObject)-1)
 
 	for k := range responseObject {
-		if k != "_" {
+		if !strings.HasPrefix(k, "_") {
 			ids = append(ids, k)
 		}
 	}

--- a/bondhome/api.go
+++ b/bondhome/api.go
@@ -130,7 +130,7 @@ func (c *restAPIClient) GetDeviceIDs() ([]string, error) {
 
 func (c *restAPIClient) newRequest(method string, urlPath string, body []byte) (*http.Request, error) {
 	req, err := http.NewRequest(method,
-		fmt.Sprintf("http://%s/%s", c.hostname, urlPath),
+		fmt.Sprintf("%s/%s", c.hostname, urlPath),
 		bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/bondhome/api_test.go
+++ b/bondhome/api_test.go
@@ -1,5 +1,3 @@
-//go:build network_test
-
 package bondhome
 
 import (
@@ -27,6 +25,9 @@ func setupTestServer(t *testing.T, requestHandler func(http.ResponseWriter, *htt
 		close(received)
 		requestHandler(w, r)
 	}))
+	t.Cleanup(func() {
+		ts.Close()
+	})
 
 	client := &restAPIClient{
 		client:   ts.Client(),

--- a/bondhome/api_test.go
+++ b/bondhome/api_test.go
@@ -137,6 +137,12 @@ func Test_restAPIClient_getDeviceIds(t *testing.T) {
 			},
 			"deviceID3": {
 				"_": "aaf392f2"
+			},
+			"_": {
+
+			},
+			"__": {
+				
 			}
 		}`
 


### PR DESCRIPTION
Addresses the issue reported in #5 